### PR TITLE
chore(travis): adds travis config to package and deploy

### DIFF
--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<settings xsi:schemaLocation='http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd'
+          xmlns='http://maven.apache.org/SETTINGS/1.0.0' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+    <servers>
+        <server>
+            <id>bintray-americanexpress-maven</id>
+            <username>${env.CI_DEPLOY_USERNAME}</username>
+            <password>${env.CI_DEPLOY_PASSWORD}</password>
+        </server>
+    </servers>
+</settings>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: java
+
+cache:
+  directories:
+    - $HOME/.m2
+
+jdk:
+  - openjdk8
+  - oraclejdk8
+  - oraclejdk9
+
+script:
+  - mvn clean test
+
+deploy:
+  provider: script
+  script: mvn clean deploy --settings=".travis.settings.xml"
+  on:
+    tags: true
+    jdk: oraclejdk8

--- a/pom.xml
+++ b/pom.xml
@@ -28,4 +28,12 @@
         </plugins>
     </build>
 
+    <distributionManagement>
+        <repository>
+            <id>bintray-americanexpress-maven</id>
+            <name>americanexpress-maven</name>
+            <url>https://api.bintray.com/maven/americanexpress/maven/com.americanexpress.jexm</url>
+        </repository>
+    </distributionManagement>
+
 </project>


### PR DESCRIPTION
adds travis config to build jexm on openjdk 8, 9, and 10, with 10 allowed to fail since it is in beta.

travis will conditionally deploy tags on openjdk8 to bintray.